### PR TITLE
Fix compatibility under D2P2:

### DIFF
--- a/lib/Dancer2/Plugin/RoutePodCoverage.pm
+++ b/lib/Dancer2/Plugin/RoutePodCoverage.pm
@@ -3,7 +3,6 @@ package Dancer2::Plugin::RoutePodCoverage;
 use strict;
 use warnings;
 
-use Dancer2;
 use Dancer2::Plugin;
 use Pod::Simple::Search;
 use Pod::Simple::SimpleTree;

--- a/t/03-pod-coverage.t
+++ b/t/03-pod-coverage.t
@@ -1,2 +1,24 @@
 use Test::Pod::Coverage tests=>1;
-pod_coverage_ok( "Dancer2::Plugin::RoutePodCoverage", "Dancer2::Plugin::RoutePodCoverage" );
+my $d2_subs = qr{
+    (
+       ClassHooks |
+       PluginKeyword |
+       dancer_app |
+       execute_plugin_hook |
+       hook |
+       keywords |
+       on_plugin_import |
+       plugin_args |
+       plugin_setting |
+       register |
+       register_hook |
+       register_plugin |
+       request |
+       var
+    )
+}x;
+pod_coverage_ok(
+    "Dancer2::Plugin::RoutePodCoverage",
+    { also_private => [ $d2_subs ] },
+    "Dancer2::Plugin::RoutePodCoverage",
+);


### PR DESCRIPTION
Importing Dancer2 in a plugin breaks the new plugin system in
Dancer2.

Additionally, the Pod coverage test grabs a few subroutines that
part of the DSL.
